### PR TITLE
Add tests for Snake direction logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Cardsnake
+
+This project uses Node's built in test runner for unit tests.
+
+## Running tests
+
+Install Node (version 18 or higher) and run:
+
+```bash
+npm test
+```
+
+This will execute all files in the `tests` directory using `node --test`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cardsnake",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/snake.test.js
+++ b/tests/snake.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Snake } from '../src/js/game/Snake.js';
+
+test('setDirection does not allow reversing direction', () => {
+  const tileSize = 20;
+  const snake = new Snake(tileSize);
+  const originalDirection = { ...snake.direction };
+  // Try to reverse direction
+  snake.setDirection(-tileSize, 0);
+  assert.deepStrictEqual(snake.direction, originalDirection);
+});


### PR DESCRIPTION
## Summary
- add Node test environment with `package.json`
- document running tests in new `README.md`
- implement sample test verifying `setDirection` prevents reversing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840d5881b10832197fde6880acdafc0